### PR TITLE
Downgrade InvMenu

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -10,7 +10,7 @@ projects:
       version: ^3.2.0
     - src: muqsit/InvMenu/InvMenu
       branch: master
-      version: ^2.1.0
+      version: 2.1.0
     - src: SOF3/await-generator/await-generator
       version: ^2.2.0
     - src: JackMD/UpdateNotifier/UpdateNotifier


### PR DESCRIPTION
Since it got the highest version available that's higher than 2.1.0, it kept getting the latest (which is 3.1.0 I think?) and wouldn't work. Now it should :)