### PR TITLE
Translation: fix plugin crash on loading

### DIFF
--- a/src/shock95x/auctionhouse/utils/Locale.php
+++ b/src/shock95x/auctionhouse/utils/Locale.php
@@ -38,6 +38,7 @@ class Locale {
 			$locale = new Config($file, Config::YAML);
 			$localeCode = basename($file, ".yml");
 			self::$translation[strtolower($localeCode)] = $locale->getAll();
+			unset(self::$translation[strtolower($localeCode)]["lang-version"]);
 			array_walk_recursive(self::$translation[strtolower($localeCode)], function (&$element) {
 				$element = str_replace("&", "\xc2\xa7", $element);
 			});

--- a/src/shock95x/auctionhouse/utils/Locale.php
+++ b/src/shock95x/auctionhouse/utils/Locale.php
@@ -40,7 +40,11 @@ class Locale {
 			self::$translation[strtolower($localeCode)] = $locale->getAll();
 			unset(self::$translation[strtolower($localeCode)]["lang-version"]);
 			array_walk_recursive(self::$translation[strtolower($localeCode)], function (&$element) {
-				$element = str_replace("&", "\xc2\xa7", $element);
+				if($element === null){
+					$element = "";
+				}else{
+					$element = str_replace("&", "\xc2\xa7", (string)$element);
+				}
 			});
 		}
 	}


### PR DESCRIPTION
This PR fixes a plugin crash due to the presence of non-string the translation files.

In particular,
- The integer key "lang-version" is now removed when loading the translation as it only used by the plugin to detect old files;
- [Translation that have null values](https://github.com/Shock95x/AuctionHouse/blob/master/resources/language/en_US.yml#L137) are now manually converted to empty strings.

Finally, to prevent crashing due to the user inputting non string values in the translation file, translations are now explicitly casted to string before being passed to str_replace.