### PR TITLE
Fix TypeError: str_replace() PHP8

### DIFF
--- a/src/shock95x/auctionhouse/utils/Locale.php
+++ b/src/shock95x/auctionhouse/utils/Locale.php
@@ -38,7 +38,7 @@ class Locale {
 			self::$translation[strtolower($localeCode)] = $config->getAll();
 			array_walk_recursive(self::$translation[strtolower($localeCode)], function (&$element) {
 				$element ??= "";
-				$element = str_replace("&", "\xc2\xa7", $element);
+				$element = str_replace("&", "\xc2\xa7", (string) $element);
 			});
 			unset(self::$translation[strtolower($localeCode)]["lang-version"]);
 		}


### PR DESCRIPTION
Fix `TypeError: "str_replace(): Argument #3 ($subject) must be of type array|string, int given"` PHP8

Issues: #89 #90 #94 